### PR TITLE
Add Playwright workflow tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Run E2E tests
+        run: pnpm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+test-results
 *.local
 
 # Editor directories and files

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "serve": "pnpm run build && cd server_automerge && pnpm run start ./config.json",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@automerge/automerge": "^2.2.9",
@@ -55,6 +56,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",
+    "@playwright/test": "^1.61.1",
     "@types/node": "^22.17.0",
     "eslint": "^9.32.0",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,9 @@ import { defineConfig, devices } from "@playwright/test";
 export default defineConfig({
   testDir: "./tests/e2e",
   fullyParallel: true,
+  reporter: process.env.CI
+    ? [["github"], ["list", { printSteps: true }]]
+    : [["list", { printSteps: true }]],
   use: {
     baseURL: "http://127.0.0.1:5173",
     trace: "on-first-retry",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  use: {
+    baseURL: "http://127.0.0.1:5173",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        launchOptions: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+          ? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH }
+          : undefined,
+      },
+    },
+  ],
+  webServer: {
+    command: "pnpm dev --host 127.0.0.1",
+    url: "http://127.0.0.1:5173",
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       '@eslint/js':
         specifier: ^9.32.0
         version: 9.32.0
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@types/node':
         specifier: ^22.17.0
         version: 22.17.0
@@ -595,6 +598,11 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
 
@@ -984,56 +992,67 @@ packages:
     resolution: {integrity: sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.46.2':
     resolution: {integrity: sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.46.2':
     resolution: {integrity: sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.46.2':
     resolution: {integrity: sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.46.2':
     resolution: {integrity: sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.46.2':
     resolution: {integrity: sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.46.2':
     resolution: {integrity: sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.46.2':
     resolution: {integrity: sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.46.2':
     resolution: {integrity: sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.46.2':
     resolution: {integrity: sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.46.2':
     resolution: {integrity: sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.46.2':
     resolution: {integrity: sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==}
@@ -1073,24 +1092,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.13.3':
     resolution: {integrity: sha512-bc+CXYlFc1t8pv9yZJGus372ldzOVscBl7encUBlU1m/Sig0+NDJLz6cXXRcFyl6ABNOApWeR4Yl7iUWx6C8og==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.13.3':
     resolution: {integrity: sha512-dFXoa0TEhohrKcxn/54YKs1iwNeW6tUkHJgXW33H381SvjKFUV53WR231jh1sWVJETjA3vsAwxKwR23s7UCmUA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.13.3':
     resolution: {integrity: sha512-ieyjisLB+ldexiE/yD8uomaZuZIbTc8tjquYln9Quh5ykOBY7LpJJYBWvWtm1g3pHv6AXlBI8Jay7Fffb6aLfA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.13.3':
     resolution: {integrity: sha512-elTQpnaX5vESSbhCEgcwXjpMsnUbqqHfEpB7ewpkAsLzKEXZaK67ihSRYAuAx6ewRQTo7DS5iTT6X5aQD3MzMw==}
@@ -1166,24 +1189,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.11':
     resolution: {integrity: sha512-m/NVRFNGlEHJrNVk3O6I9ggVuNjXHIPoD6bqay/pubtYC9QIdAMpS+cswZQPBLvVvEF6GtSNONbDkZrjWZXYNQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.11':
     resolution: {integrity: sha512-YW6sblI7xukSD2TdbbaeQVDysIm/UPJtObHJHKxDEcW2exAtY47j52f8jZXkqE1krdnkhCMGqP3dbniu1Te2Fg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.11':
     resolution: {integrity: sha512-e3C/RRhGunWYNC3aSF7exsQkdXzQ/M+aYuZHKnw4U7KQwTJotnWsGOIVih0s2qQzmEzOFIJ3+xt7iq67K/p56Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.11':
     resolution: {integrity: sha512-Xo1+/GU0JEN/C/dvcammKHzeM6NqKovG+6921MR6oadee5XPBaKOumrJCXvopJ/Qb5TH7LX/UAywbqrP4lax0g==}
@@ -1688,6 +1715,11 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1878,24 +1910,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -2058,6 +2094,16 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -2255,6 +2301,7 @@ packages:
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tinyglobby@0.2.14:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
@@ -2343,10 +2390,12 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vary@1.1.2:
@@ -2907,6 +2956,10 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
 
   '@radix-ui/number@1.1.1': {}
 
@@ -4010,6 +4063,9 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4298,6 +4354,14 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.6:
     dependencies:

--- a/src/components/dashboard/settings.tsx
+++ b/src/components/dashboard/settings.tsx
@@ -130,7 +130,7 @@ export const DashboardSettings: FC<{ dashboard_url: AutomergeUrl }> = ({ dashboa
   return (
     <Sheet>
       <SheetTrigger asChild>
-        <button data-testid="dashboard-settings-trigger"><Menu /></button>
+        <button type="button" data-testid="dashboard-settings-trigger"><Menu /></button>
       </SheetTrigger>
       <SheetContent side="left" className="max-w-md w-fit h-full" aria-describedby={undefined}>
         <SheetHeader>

--- a/src/components/dashboard/settings.tsx
+++ b/src/components/dashboard/settings.tsx
@@ -71,23 +71,25 @@ const SingleProjectSettings: FC<{ dashboard_url: AutomergeUrl, purl: AutomergeUr
   }
 
   return (
-    <li key={purl} className="flex flex-col gap-2">
-      <div className="flex justify-center">{purl}</div>
+    <li key={purl} className="flex flex-col gap-2" data-testid="project-settings" data-project-id={purl}>
+      <div className="flex justify-center" data-testid="project-url">{purl}</div>
       <div className="flex flex-row gap-2">
         <Label className="w-fit">Petname</Label>
         <Input
           value={project.petname}
           onChange={(event) => update_project_petname(changeDoc, purl, event.target.value)}
           className="flex"
+          data-testid="project-petname"
         />
         <button
+          data-testid="export-project"
           onClick={() => exportProject(repo, purl)}>
           <Download />
         </button>
       </div>
       <Dialog>
         <DialogTrigger asChild>
-          <Button variant="outline">Delete</Button>
+          <Button variant="outline" data-testid="delete-project">Delete</Button>
         </DialogTrigger>
         <DialogContent aria-describedby={undefined}>
           <DialogHeader>
@@ -95,7 +97,7 @@ const SingleProjectSettings: FC<{ dashboard_url: AutomergeUrl, purl: AutomergeUr
           </DialogHeader>
           <div className="flex flex-col gap-2">
             <Label>Are you sure you want to delete this project?</Label>
-            <Button variant="destructive" onClick={() => delete_project(changeDoc, purl)}>
+            <Button variant="destructive" data-testid="confirm-delete-project" onClick={() => delete_project(changeDoc, purl)}>
               Delete
             </Button>
           </div>
@@ -128,7 +130,7 @@ export const DashboardSettings: FC<{ dashboard_url: AutomergeUrl }> = ({ dashboa
   return (
     <Sheet>
       <SheetTrigger asChild>
-        <button><Menu /></button>
+        <button data-testid="dashboard-settings-trigger"><Menu /></button>
       </SheetTrigger>
       <SheetContent side="left" className="max-w-md w-fit h-full" aria-describedby={undefined}>
         <SheetHeader>
@@ -157,10 +159,12 @@ export const DashboardSettings: FC<{ dashboard_url: AutomergeUrl }> = ({ dashboa
               placeholder="Petname"
               className=""
               value={input_new_project_petname}
+              data-testid="new-project-petname"
               onChange={(event) => update_input_new_project_petname(event.target.value)} />
             <Button
               variant="outline"
               className=""
+              data-testid="create-project"
               onClick={() => create_new_project(repo, changeDoc, input_new_project_petname)}
             >
               Create new project
@@ -170,11 +174,13 @@ export const DashboardSettings: FC<{ dashboard_url: AutomergeUrl }> = ({ dashboa
           <div className="flex flex-col gap-2">
             <div className="flex flex-row gap-2">
               <Input placeholder="Petname" className=""
+                data-testid="existing-project-petname"
                 onChange={(event) => update_input_existing_project_petname(event.target.value)} />
               <Input placeholder="automerge:<token>" className=""
+                data-testid="existing-project-url"
                 onChange={(event) => update_input_existing_project_url(event.target.value)} />
             </div>
-            <Button variant="outline" className="" onClick={() => {
+            <Button variant="outline" className="" data-testid="add-existing-project" onClick={() => {
               if (isValidAutomergeUrl(input_existing_project_url)) {
                 add_existing_project(changeDoc, input_existing_project_url, input_existing_project_petname)
               }

--- a/src/components/project/project.tsx
+++ b/src/components/project/project.tsx
@@ -49,8 +49,8 @@ export const Project: FC<{ project_url: AutomergeUrl, petname: string }> = ({ pr
 
     return (
         <DndContext onDragEnd={handleDragEnd} modifiers={[restrictToVerticalAxis]}>
-            <div className="bg-card flex flex-col gap-2 p-2">
-                <Label className="justify-center">{petname}</Label>
+            <div className="bg-card flex flex-col gap-2 p-2" data-testid="project" data-project-id={project_url}>
+                <Label className="justify-center" data-testid="project-title">{petname}</Label>
                 <div className="py-1">
                     <Separator />
                 </div>
@@ -98,6 +98,7 @@ export const Project: FC<{ project_url: AutomergeUrl, petname: string }> = ({ pr
                     type="button"
                     variant="outline"
                     className="w-full"
+                    data-testid="add-task"
                     onClick={() => add_new_task(changeDoc)}>
                     Add Task
                 </Button>

--- a/src/components/project/store.tsx
+++ b/src/components/project/store.tsx
@@ -82,10 +82,10 @@ export function delete_task(changeDoc: ChangeDoc, task_url: AutomergeUrl): void 
 function calculate_next_order(prev_order: number | null, next_order: number | null) {
     let low = 0;
     let high = 1;
-    if (prev_order && next_order) {
+    if (prev_order !== null && next_order !== null) {
         low = Math.min(prev_order, next_order);
         high = Math.max(prev_order, next_order);
-    } else if (prev_order || next_order) {
+    } else if (prev_order !== null || next_order !== null) {
         const v = (prev_order ?? next_order) as number;
         low = Math.min(v, 0);
         high = Math.max(v, 1);

--- a/src/components/task/task.tsx
+++ b/src/components/task/task.tsx
@@ -29,6 +29,7 @@ export const Task: FC<{ project_url: AutomergeUrl, task_url: AutomergeUrl}> = ({
         <button
             type="button"
             className="touch-none"
+            data-testid="task-drag-handle"
             {...listeners}
             {...attributes}>
             <DragHandle />
@@ -45,6 +46,8 @@ export const Task: FC<{ project_url: AutomergeUrl, task_url: AutomergeUrl}> = ({
         <li 
           key={task_url} 
           className="flex flex-row gap-2 p-1 bg-card rounded"
+          data-testid="task"
+          data-task-id={task_url}
           style={transform_style} 
           ref={setNodeRef}>
             <div className="flex items-center justify-center">
@@ -60,6 +63,7 @@ export const Task: FC<{ project_url: AutomergeUrl, task_url: AutomergeUrl}> = ({
                 }}
                 wrap="soft"
                 className="resize-none scrollbar-hidden w-full max-w-full"
+                data-testid="task-description"
                 value={task.description}
                 onChange={
                     (event) => update_task_description(changeDoc, task_url, event.target.value)

--- a/tests/e2e/project-workflows.spec.ts
+++ b/tests/e2e/project-workflows.spec.ts
@@ -1,7 +1,28 @@
 import { expect, type Locator, type Page, test } from "@playwright/test";
 
+async function openSettings(page: Page) {
+  const newProjectInput = page.getByTestId("new-project-petname");
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    if (await newProjectInput.isVisible()) {
+      return;
+    }
+
+    await page.getByTestId("dashboard-settings-trigger").click({ force: true });
+
+    try {
+      await expect(newProjectInput).toBeVisible({ timeout: 1000 });
+      return;
+    } catch {
+      await page.keyboard.press("Escape");
+    }
+  }
+
+  await expect(newProjectInput).toBeVisible();
+}
+
 async function createProject(page: Page, petname: string) {
-  await page.getByTestId("dashboard-settings-trigger").click();
+  await openSettings(page);
   await page.getByTestId("new-project-petname").fill(petname);
   await page.getByTestId("create-project").click();
   await expect(page.getByTestId("project").filter({ hasText: petname })).toBeVisible();
@@ -83,6 +104,8 @@ async function projectSettingsByPetname(page: Page, petname: string) {
 }
 
 test("creates projects, reorders tasks, and re-adds an existing project", async ({ page }) => {
+  test.setTimeout(60_000);
+
   await page.goto("/");
   await expect(page.getByText("Connected")).toBeVisible();
 
@@ -109,7 +132,7 @@ test("creates projects, reorders tasks, and re-adds an existing project", async 
   await dragTask(secondProject, "beta", "alpha");
   await expectTaskOrder(secondProject, ["beta", "alpha", "gamma"]);
 
-  await page.getByTestId("dashboard-settings-trigger").click();
+  await openSettings(page);
   const secondProjectSettings = await projectSettingsByPetname(page, "Project Two");
   const projectUrl = await secondProjectSettings.getByTestId("project-url").textContent();
   expect(projectUrl).toBeTruthy();

--- a/tests/e2e/project-workflows.spec.ts
+++ b/tests/e2e/project-workflows.spec.ts
@@ -106,47 +106,73 @@ async function projectSettingsByPetname(page: Page, petname: string) {
 test("creates projects, reorders tasks, and re-adds an existing project", async ({ page }) => {
   test.setTimeout(60_000);
 
-  await page.goto("/");
-  await expect(page.getByText("Connected")).toBeVisible();
+  await test.step("load dashboard", async () => {
+    await page.goto("/");
+    await expect(page.getByText("Connected")).toBeVisible();
+  });
 
-  const firstProject = await createProject(page, "Project One");
-  await addTasks(firstProject, ["one", "two", "three", "four"]);
-  await expectTaskOrder(firstProject, ["one", "two", "three", "four"]);
+  let firstProject: Locator;
+  await test.step("create first project with four tasks", async () => {
+    firstProject = await createProject(page, "Project One");
+    await addTasks(firstProject, ["one", "two", "three", "four"]);
+    await expectTaskOrder(firstProject, ["one", "two", "three", "four"]);
+  });
 
-  await dragTask(firstProject, "two", "one");
-  await expectTaskOrder(firstProject, ["two", "one", "three", "four"]);
+  await test.step("reorder first project: middle task to top", async () => {
+    await dragTask(firstProject, "two", "one");
+    await expectTaskOrder(firstProject, ["two", "one", "three", "four"]);
+  });
 
-  await dragTask(firstProject, "four", "one");
-  await expectTaskOrder(firstProject, ["two", "four", "one", "three"]);
+  await test.step("reorder first project: bottom task to middle", async () => {
+    await dragTask(firstProject, "four", "one");
+    await expectTaskOrder(firstProject, ["two", "four", "one", "three"]);
+  });
 
-  await dragTask(firstProject, "two", "one");
-  await expectTaskOrder(firstProject, ["four", "one", "two", "three"]);
+  await test.step("reorder first project: top task to middle", async () => {
+    await dragTask(firstProject, "two", "one");
+    await expectTaskOrder(firstProject, ["four", "one", "two", "three"]);
+  });
 
-  await dragTask(firstProject, "three", "two");
-  await expectTaskOrder(firstProject, ["four", "one", "three", "two"]);
+  await test.step("reorder first project: bottom task to middle", async () => {
+    await dragTask(firstProject, "three", "two");
+    await expectTaskOrder(firstProject, ["four", "one", "three", "two"]);
+  });
 
-  const secondProject = await createProject(page, "Project Two");
-  await addTasks(secondProject, ["alpha", "beta", "gamma"]);
-  await expectTaskOrder(secondProject, ["alpha", "beta", "gamma"]);
+  let secondProject: Locator;
+  await test.step("create second project with three tasks", async () => {
+    secondProject = await createProject(page, "Project Two");
+    await addTasks(secondProject, ["alpha", "beta", "gamma"]);
+    await expectTaskOrder(secondProject, ["alpha", "beta", "gamma"]);
+  });
 
-  await dragTask(secondProject, "beta", "alpha");
-  await expectTaskOrder(secondProject, ["beta", "alpha", "gamma"]);
+  await test.step("reorder second project tasks", async () => {
+    await dragTask(secondProject, "beta", "alpha");
+    await expectTaskOrder(secondProject, ["beta", "alpha", "gamma"]);
+  });
 
-  await openSettings(page);
-  const secondProjectSettings = await projectSettingsByPetname(page, "Project Two");
-  const projectUrl = await secondProjectSettings.getByTestId("project-url").textContent();
-  expect(projectUrl).toBeTruthy();
+  let projectUrl: string;
+  await test.step("copy second project URL and delete project", async () => {
+    await openSettings(page);
+    const secondProjectSettings = await projectSettingsByPetname(page, "Project Two");
+    const maybeProjectUrl = await secondProjectSettings.getByTestId("project-url").textContent();
+    expect(maybeProjectUrl).toBeTruthy();
+    projectUrl = maybeProjectUrl as string;
 
-  await secondProjectSettings.getByTestId("delete-project").click();
-  await page.getByTestId("confirm-delete-project").click();
-  await expect(projectByName(page, "Project Two")).toHaveCount(0);
+    await secondProjectSettings.getByTestId("delete-project").click();
+    await page.getByTestId("confirm-delete-project").click();
+    await expect(projectByName(page, "Project Two")).toHaveCount(0);
+  });
 
-  await page.getByTestId("existing-project-petname").fill("Project Two Restored");
-  await page.getByTestId("existing-project-url").fill(projectUrl as string);
-  await page.getByTestId("add-existing-project").click();
-  await page.keyboard.press("Escape");
+  await test.step("re-add deleted project by URL", async () => {
+    await page.getByTestId("existing-project-petname").fill("Project Two Restored");
+    await page.getByTestId("existing-project-url").fill(projectUrl);
+    await page.getByTestId("add-existing-project").click();
+    await page.keyboard.press("Escape");
+  });
 
-  const restoredProject = projectByName(page, "Project Two Restored");
-  await expect(restoredProject).toBeVisible();
-  await expectTaskOrder(restoredProject, ["beta", "alpha", "gamma"]);
+  await test.step("verify restored project still has reordered tasks", async () => {
+    const restoredProject = projectByName(page, "Project Two Restored");
+    await expect(restoredProject).toBeVisible();
+    await expectTaskOrder(restoredProject, ["beta", "alpha", "gamma"]);
+  });
 });

--- a/tests/e2e/project-workflows.spec.ts
+++ b/tests/e2e/project-workflows.spec.ts
@@ -1,0 +1,129 @@
+import { expect, type Locator, type Page, test } from "@playwright/test";
+
+async function createProject(page: Page, petname: string) {
+  await page.getByTestId("dashboard-settings-trigger").click();
+  await page.getByTestId("new-project-petname").fill(petname);
+  await page.getByTestId("create-project").click();
+  await expect(page.getByTestId("project").filter({ hasText: petname })).toBeVisible();
+  await page.keyboard.press("Escape");
+
+  return projectByName(page, petname);
+}
+
+function projectByName(page: Page, petname: string) {
+  return page.getByTestId("project").filter({ has: page.getByTestId("project-title").filter({ hasText: petname }) });
+}
+
+async function addTask(project: Locator, description: string) {
+  await project.getByTestId("add-task").click();
+  const task = project.getByTestId("task").last();
+  await task.getByTestId("task-description").fill(description);
+  await expect(task.getByTestId("task-description")).toHaveValue(description);
+}
+
+async function taskDescriptions(project: Locator) {
+  return project.getByTestId("task-description").evaluateAll((textareas) => {
+    return textareas.map((textarea) => (textarea as HTMLTextAreaElement).value);
+  });
+}
+
+async function taskByDescription(project: Locator, description: string) {
+  const tasks = project.getByTestId("task");
+  const count = await tasks.count();
+
+  for (let i = 0; i < count; i += 1) {
+    const task = tasks.nth(i);
+    if (await task.getByTestId("task-description").inputValue() === description) {
+      return task;
+    }
+  }
+
+  throw new Error(`Task not found: ${description}`);
+}
+
+async function expectTaskOrder(project: Locator, expected: string[]) {
+  await expect.poll(() => taskDescriptions(project)).toEqual(expected);
+}
+
+async function dragTask(project: Locator, from: string, to: string) {
+  const source = await taskByDescription(project, from);
+  const target = await taskByDescription(project, to);
+  const sourceBox = await source.getByTestId("task-drag-handle").boundingBox();
+  const targetBox = await target.boundingBox();
+
+  if (!sourceBox || !targetBox) {
+    throw new Error(`Unable to drag ${from} to ${to}`);
+  }
+
+  const page = project.page();
+  await page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height / 2, { steps: 10 });
+  await page.mouse.up();
+}
+
+async function addTasks(project: Locator, descriptions: string[]) {
+  for (const description of descriptions) {
+    await addTask(project, description);
+  }
+}
+
+async function projectSettingsByPetname(page: Page, petname: string) {
+  const settings = page.getByTestId("project-settings");
+  const count = await settings.count();
+
+  for (let i = 0; i < count; i += 1) {
+    const projectSettings = settings.nth(i);
+    if (await projectSettings.getByTestId("project-petname").inputValue() === petname) {
+      return projectSettings;
+    }
+  }
+
+  throw new Error(`Project settings not found: ${petname}`);
+}
+
+test("creates projects, reorders tasks, and re-adds an existing project", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByText("Connected")).toBeVisible();
+
+  const firstProject = await createProject(page, "Project One");
+  await addTasks(firstProject, ["one", "two", "three", "four"]);
+  await expectTaskOrder(firstProject, ["one", "two", "three", "four"]);
+
+  await dragTask(firstProject, "two", "one");
+  await expectTaskOrder(firstProject, ["two", "one", "three", "four"]);
+
+  await dragTask(firstProject, "four", "one");
+  await expectTaskOrder(firstProject, ["two", "four", "one", "three"]);
+
+  await dragTask(firstProject, "two", "one");
+  await expectTaskOrder(firstProject, ["four", "one", "two", "three"]);
+
+  await dragTask(firstProject, "three", "two");
+  await expectTaskOrder(firstProject, ["four", "one", "three", "two"]);
+
+  const secondProject = await createProject(page, "Project Two");
+  await addTasks(secondProject, ["alpha", "beta", "gamma"]);
+  await expectTaskOrder(secondProject, ["alpha", "beta", "gamma"]);
+
+  await dragTask(secondProject, "beta", "alpha");
+  await expectTaskOrder(secondProject, ["beta", "alpha", "gamma"]);
+
+  await page.getByTestId("dashboard-settings-trigger").click();
+  const secondProjectSettings = await projectSettingsByPetname(page, "Project Two");
+  const projectUrl = await secondProjectSettings.getByTestId("project-url").textContent();
+  expect(projectUrl).toBeTruthy();
+
+  await secondProjectSettings.getByTestId("delete-project").click();
+  await page.getByTestId("confirm-delete-project").click();
+  await expect(projectByName(page, "Project Two")).toHaveCount(0);
+
+  await page.getByTestId("existing-project-petname").fill("Project Two Restored");
+  await page.getByTestId("existing-project-url").fill(projectUrl as string);
+  await page.getByTestId("add-existing-project").click();
+  await page.keyboard.press("Escape");
+
+  const restoredProject = projectByName(page, "Project Two Restored");
+  await expect(restoredProject).toBeVisible();
+  await expectTaskOrder(restoredProject, ["beta", "alpha", "gamma"]);
+});

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "@playwright/test";
+
+test("loads the dashboard", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByText("Connected")).toBeVisible();
+  await expect(page.getByText("TBD")).toBeVisible();
+});

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,8 +1,0 @@
-import { expect, test } from "@playwright/test";
-
-test("loads the dashboard", async ({ page }) => {
-  await page.goto("/");
-
-  await expect(page.getByText("Connected")).toBeVisible();
-  await expect(page.getByText("TBD")).toBeVisible();
-});


### PR DESCRIPTION
## Summary
- include PR #3's minimal task reorder fix: treat order 0 as a valid bound when calculating the next order
- add Playwright test infrastructure and CI
- add stable DOM hooks for projects, tasks, task drag handles, and project settings controls
- cover the requested workflow: create projects, add tasks, reorder middle/end task positions, delete a project, re-add it by Automerge URL, and verify tasks persist

## Verification
- pnpm --config.verify-deps-before-run=false run build
- PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=$(which chromium) pnpm --config.verify-deps-before-run=false run test:e2e via nix shell with nodejs_22, pnpm, and chromium

## Notes
- PR #3 is folded into this branch so CI can validate the expanded workflow test directly.
- On NixOS, the downloaded Playwright browser cannot execute directly, so the config supports PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH for a system/Nix Chromium.