### PR TITLE
Add flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Nix
+        uses: cachix/install-nix-action@v31
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -33,6 +36,12 @@ jobs:
 
       - name: Build
         run: pnpm run build
+
+      - name: Check flake
+        run: nix flake check
+
+      - name: Build flake package
+        run: nix build .#default
 
       - name: Run E2E tests
         run: pnpm run test:e2e

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Run and serve files with `npm run serve -- server/config.json`
 
+## Nix
+
+This repository provides a flake package and NixOS module for running the app as
+a systemd service. See [nix/README.md](nix/README.md).
+
 # Features or task list
 
 - [x] Multi-project

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,217 @@
+{
+  description = "A small Automerge-backed todo application";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    systems.url = "github:nix-systems/default";
+  };
+
+  outputs = { self, nixpkgs, systems }:
+    let
+      eachSystem = nixpkgs.lib.genAttrs (import systems);
+    in
+    {
+      packages = eachSystem (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          lib = pkgs.lib;
+          nodejs = pkgs.nodejs_22;
+          pnpm = pkgs.pnpm;
+
+          cleanSrc = lib.cleanSourceWith {
+            src = ./.;
+            filter = path: type:
+              let
+                name = baseNameOf path;
+              in
+              !(name == ".git"
+                || name == "node_modules"
+                || name == "dist"
+                || name == "result"
+                || name == "test-results");
+          };
+
+          serverSrc = lib.cleanSourceWith {
+            src = ./server_automerge;
+            filter = path: type:
+              let
+                name = baseNameOf path;
+              in
+              !(name == "node_modules" || name == "result");
+          };
+
+          frontend = pkgs.stdenv.mkDerivation (finalAttrs: {
+            pname = "ps-todos-frontend";
+            version = "0.0.0";
+            src = cleanSrc;
+
+            pnpmDeps = pkgs.fetchPnpmDeps {
+              inherit (finalAttrs) pname version src;
+              fetcherVersion = 3;
+              hash = "sha256-OrchET0B8/PCeIrylsF7u0aWk6Es2dDlrC42DxQEI7E=";
+            };
+
+            nativeBuildInputs = [
+              nodejs
+              pkgs.pnpmConfigHook
+              pnpm
+            ];
+
+            buildPhase = ''
+              runHook preBuild
+              pnpm run build
+              runHook postBuild
+            '';
+
+            installPhase = ''
+              runHook preInstall
+              mkdir -p $out/share/ps-todos/application
+              cp -r dist/. $out/share/ps-todos/application/
+              runHook postInstall
+            '';
+          });
+
+          server = pkgs.stdenv.mkDerivation (finalAttrs: {
+            pname = "ps-todos-server";
+            version = "0.0.1";
+            src = serverSrc;
+
+            pnpmDeps = pkgs.fetchPnpmDeps {
+              inherit (finalAttrs) pname version src;
+              fetcherVersion = 3;
+              hash = "sha256-BzyjkN57M9BU7i5/Qnd57TyOmbTgulD9IgrlIZz18OE=";
+            };
+
+            nativeBuildInputs = [
+              nodejs
+              pkgs.pnpmConfigHook
+              pnpm
+              pkgs.makeWrapper
+            ];
+
+            dontBuild = true;
+
+            installPhase = ''
+              runHook preInstall
+              mkdir -p $out/lib/ps-todos/server $out/bin
+              cp server.js package.json $out/lib/ps-todos/server/
+              cp -r node_modules $out/lib/ps-todos/server/
+              makeWrapper ${nodejs}/bin/node $out/bin/ps-todos-server \
+                --add-flags "$out/lib/ps-todos/server/server.js"
+              runHook postInstall
+            '';
+          });
+
+          ps-todos = pkgs.symlinkJoin {
+            name = "ps-todos";
+            paths = [ frontend server ];
+          };
+        in
+        {
+          inherit frontend server ps-todos;
+          default = ps-todos;
+        });
+
+      apps = eachSystem (system: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/ps-todos-server";
+        };
+      });
+
+      nixosModules.default = { config, lib, pkgs, ... }:
+        let
+          cfg = config.services.ps-todos;
+          configFile = pkgs.writeText "ps-todos-config.json" (builtins.toJSON (cfg.extraConfig // {
+            inherit (cfg) dashboards port;
+            application = "${cfg.package}/share/ps-todos/application";
+            database = cfg.dataDir;
+          }));
+        in
+        {
+          options.services.ps-todos = {
+            enable = lib.mkEnableOption "ps-todos";
+
+            package = lib.mkOption {
+              type = lib.types.package;
+              default = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+              defaultText = lib.literalExpression "inputs.ps-todos.packages.\${pkgs.system}.default";
+              description = "ps-todos package to run.";
+            };
+
+            user = lib.mkOption {
+              type = lib.types.str;
+              default = "ps-todos";
+              description = "User account that runs the ps-todos service.";
+            };
+
+            group = lib.mkOption {
+              type = lib.types.str;
+              default = "ps-todos";
+              description = "Group account that runs the ps-todos service.";
+            };
+
+            port = lib.mkOption {
+              type = lib.types.port;
+              default = 5000;
+              description = "TCP port for the HTTP and WebSocket server.";
+            };
+
+            dataDir = lib.mkOption {
+              type = lib.types.path;
+              default = "/var/lib/ps-todos";
+              description = "Directory used for Automerge document storage.";
+            };
+
+            dashboards = lib.mkOption {
+              type = lib.types.attrsOf lib.types.str;
+              default = { };
+              example = {
+                "automerge:2ezdQGspSBhzs9BcfKkcbsiAsj9V" = "personal";
+              };
+              description = "Allowed dashboard Automerge URLs.";
+            };
+
+            extraConfig = lib.mkOption {
+              type = lib.types.attrs;
+              default = { };
+              description = "Additional JSON config passed to the ps-todos server.";
+            };
+
+            openFirewall = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = "Open the configured port in the firewall.";
+            };
+          };
+
+          config = lib.mkIf cfg.enable {
+            users.groups.${cfg.group} = { };
+            users.users.${cfg.user} = {
+              isSystemUser = true;
+              group = cfg.group;
+              home = cfg.dataDir;
+            };
+
+            systemd.tmpfiles.rules = [
+              "d ${cfg.dataDir} 0750 ${cfg.user} ${cfg.group} -"
+            ];
+
+            systemd.services.ps-todos = {
+              description = "ps-todos";
+              after = [ "network.target" ];
+              wantedBy = [ "multi-user.target" ];
+              serviceConfig = {
+                ExecStart = "${cfg.package}/bin/ps-todos-server ${configFile} ${cfg.dataDir}";
+                Restart = "on-failure";
+                User = cfg.user;
+                Group = cfg.group;
+                WorkingDirectory = cfg.dataDir;
+              };
+            };
+
+            networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.port ];
+          };
+        };
+    };
+}

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,50 @@
+# Nix packaging
+
+This repository exposes a flake package and a NixOS module.
+
+Build the combined package:
+
+```sh
+nix build .#ps-todos
+```
+
+Run the server directly with a JSON config:
+
+```sh
+nix run . -- /path/to/config.json /var/lib/ps-todos
+```
+
+The package provides:
+
+- `bin/ps-todos-server`
+- `share/ps-todos/application`, the built static frontend
+
+Example NixOS configuration:
+
+```nix
+{
+  inputs.ps-todos.url = "github:Cjen1/ps-todos";
+
+  outputs = { nixpkgs, ps-todos, ... }: {
+    nixosConfigurations.my-host = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        ps-todos.nixosModules.default
+        {
+          services.ps-todos = {
+            enable = true;
+            port = 5000;
+            openFirewall = true;
+            dashboards = {
+              "automerge:2ezdQGspSBhzs9BcfKkcbsiAsj9V" = "personal";
+            };
+          };
+        }
+      ];
+    };
+  };
+}
+```
+
+The NixOS module writes a server config containing the packaged frontend path and
+starts `ps-todos-server` as a systemd service.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "pnpm dev --host 127.0.0.1",
+    command: "bash tests/e2e/run-flake-server.sh",
     url: "http://127.0.0.1:5173",
     reuseExistingServer: !process.env.CI,
   },

--- a/tests/e2e/run-flake-server.sh
+++ b/tests/e2e/run-flake-server.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+port="${PORT:-5173}"
+package="${PS_TODOS_PACKAGE:-}"
+
+if [ -z "$package" ]; then
+  package="$(nix build --no-link --print-out-paths .#default)"
+fi
+
+data_dir="${PS_TODOS_DATA_DIR:-$(mktemp -d)}"
+config_file="$(mktemp)"
+
+cat > "$config_file" <<EOF
+{
+  "database": "$data_dir",
+  "port": $port,
+  "dashboards": {},
+  "application": "$package/share/ps-todos/application"
+}
+EOF
+
+exec "$package/bin/ps-todos-server" "$config_file" "$data_dir"


### PR DESCRIPTION
## Summary
- add a Nix flake with frontend, server, and combined ps-todos packages
- expose a NixOS module at nixosModules.default for running ps-todos as a systemd service
- document flake package/module usage in nix/README.md and link it from README.md
- update Playwright E2E tests to start the flake-built package instead of Vite
- update CI to install Nix, check the flake, build the flake package, and run E2E against it

## Verification
- nix build .#default
- nix flake check
- PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=$(which chromium) pnpm --config.verify-deps-before-run=false run test:e2e via nix shell with nodejs_22, pnpm, and chromium